### PR TITLE
Added <Contributor>, <Unit>, and <up_axis> to <asset> </asset> for 3dsmax 2015

### DIFF
--- a/src/convert/collada.rs
+++ b/src/convert/collada.rs
@@ -58,8 +58,14 @@ fn write_asset<W: Write>(w: &mut W) -> Result<()> {
     let iso8601_datetime = time::strftime("%FT%TZ", &now)?;
     write_lines!(w,
         r##"  <asset>"##,
+		r##"    <contributor>"##,
+		r##"	<author>Apicula</author>"##,
+		r##"	<authoring_tool>Apicula</authoring_tool>"##,
+		r##"	</contributor>"##,
         r##"    <created>{time}</created>"##,
         r##"    <modified>{time}</modified>"##,
+		r##"	<unit name="meter" meter="1"/>"##,
+		r##"	<up_axis>Z_UP</up_axis>"##,
         r##"  </asset>"##;
         time = iso8601_datetime,
     )?;


### PR DESCRIPTION
3dsmax 2015 can't into reading collada without <contributor> and probably the other things but it's funnier thinking it can't import it because of some minor text.

Because what ever reason, 3dsmax 2015 needs to know who wrote the collada, It crashed 3ds max even with just the two things that seemed logical to add Unit & Up_Axis, Blender doesn't care about this stuff.