### PR TITLE
Add cli flags for various viewer settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +91,7 @@ dependencies = [
  "json",
  "log",
  "png",
+ "regex",
  "termcolor",
  "time",
  "wild",
@@ -1163,6 +1173,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ glium = { git = "https://github.com/scurest/glium.git", branch = "vsync" }
 json = "0.12.4"
 log = { version = "0.4.6", features = ["std"] }
 png = "0.17"
+regex = "1"
 termcolor = "1"
 time = "0.1.36"
 wild = "2.0.2"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -86,6 +86,22 @@ static ALL_ANIMATIONS_OPT: Opt = Opt {
     short: "", long: "all-animations", flag: true,
     help: "--all-animations          don't guess which joint anims go with a model, just try them all",
 };
+static WINDOW_WIDTH_OPT: Opt = Opt {
+    short: "", long: "window-width", flag: false,
+    help: "--window-width <width>    width in pixels of viewer window",
+};
+static WINDOW_HEIGHT_OPT: Opt = Opt {
+    short: "", long: "window-height", flag: false,
+    help: "--window-height <height>  height in pixels of viewer window",
+};
+static ANIMATION_FPS_OPT: Opt = Opt {
+    short: "", long: "animation-fps", flag: false,
+    help: "--animation-fps <fps>     speed in frames/second to play animations at",
+};
+static BG_COLOR_OPT: Opt = Opt {
+    short: "", long: "bg-color", flag: false,
+    help: "--bg-color <hex code>     background color to use for the viewer",
+};
 static MORE_TEXTURES_OPT: Opt = Opt {
     short: "", long: "more-textures", flag: true,
     help: "--more-textures           try to dump images for unused textures too",
@@ -199,7 +215,7 @@ fn show_info_help_and_exit() -> ! {
 }
 
 
-static VIEW_OPTS: &[&Opt] = &[&ALL_ANIMATIONS_OPT, &HELP_OPT];
+static VIEW_OPTS: &[&Opt] = &[&ALL_ANIMATIONS_OPT, &WINDOW_WIDTH_OPT, &WINDOW_HEIGHT_OPT, &ANIMATION_FPS_OPT, &BG_COLOR_OPT, &HELP_OPT];
 
 fn view(p: &mut Parse) {
     parse_opts(p, VIEW_OPTS);

--- a/src/viewer/config.rs
+++ b/src/viewer/config.rs
@@ -1,0 +1,44 @@
+use crate::cli::Args;
+use crate::errors::Result;
+
+#[derive(Clone)]
+pub struct Config {
+    /// Initial window width.
+    pub window_width: u32,
+    /// Initial window height.
+    pub window_height: u32,
+    /// Window background color.
+    pub bg_color: (f32, f32, f32, f32),
+    /// Near-plane distance for perspective.
+    pub z_near: f32,
+    /// Far-plane distance for perspective.
+    pub z_far: f32,
+    /// Vertical field-of-view for perspective (radians).
+    pub fov_y: f32,
+    /// Animation framerate (seconds/frame)
+    pub animation_framerate: f64,
+    /// Calculate FPS over intervals of this length (seconds).
+    pub fps_interval: f64,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            window_width: 640,
+            window_height: 480,
+            bg_color: (0.3, 0.3, 0.3, 1.0),
+            z_near: 0.01,
+            z_far: 4000.0,
+            fov_y: 1.1,
+            animation_framerate: 1.0 / 60.0,
+            fps_interval: 2.0,
+        }
+    }
+}
+
+impl Config {
+    pub fn from_cli_args(args: &Args) -> Result<Config> {
+        let mut config = Config::default();
+        Ok(config)
+    }
+}

--- a/src/viewer/fps.rs
+++ b/src/viewer/fps.rs
@@ -1,18 +1,20 @@
-use super::FPS_INTERVAL;
+use super::config::Config;
 
 /// Tracks frames per second.
 pub struct FpsCounter {
     fps: f64,
     time_acc: f64,
     frames_acc: f64,
+    config: Config,
 }
 
 impl FpsCounter {
-    pub fn new() -> FpsCounter {
+    pub fn new(config: &Config) -> FpsCounter {
         FpsCounter {
             fps: 0.0,
             time_acc: 0.0,
             frames_acc: 0.0,
+            config: config.clone(),
         }
     }
 
@@ -24,7 +26,7 @@ impl FpsCounter {
         self.time_acc += dt;
         self.frames_acc += 1.0;
 
-        if self.time_acc > FPS_INTERVAL {
+        if self.time_acc > self.config.fps_interval {
             self.fps = self.frames_acc / self.time_acc;
             self.time_acc = 0.0;
             self.frames_acc = 0.0;

--- a/src/viewer/fps.rs
+++ b/src/viewer/fps.rs
@@ -1,20 +1,20 @@
 use super::config::Config;
 
 /// Tracks frames per second.
-pub struct FpsCounter {
+pub struct FpsCounter<'a> {
     fps: f64,
     time_acc: f64,
     frames_acc: f64,
-    config: Config,
+    config: &'a Config,
 }
 
-impl FpsCounter {
-    pub fn new(config: &Config) -> FpsCounter {
+impl<'a> FpsCounter<'a> {
+    pub fn new(config: &'a Config) -> FpsCounter<'a> {
         FpsCounter {
             fps: 0.0,
             time_acc: 0.0,
             frames_acc: 0.0,
-            config: config.clone(),
+            config: config,
         }
     }
 

--- a/src/viewer/main_loop.rs
+++ b/src/viewer/main_loop.rs
@@ -2,19 +2,20 @@ use glium::winit;
 use winit::dpi::{PhysicalSize, PhysicalPosition};
 use winit::keyboard::ModifiersState;
 use super::viewer::Viewer;
+use super::config::Config;
 use crate::db::Database;
 use crate::connection::Connection;
 
-pub fn main_loop(db: Database, conn: Connection) {
+pub fn main_loop(config: &Config, db: Database, conn: Connection) {
     let event_loop = winit::event_loop::EventLoop::builder()
         .build()
         .expect("event loop building");
     let (window, display) = glium::backend::glutin::SimpleWindowBuilder::new()
-        .with_inner_size(super::WINDOW_WIDTH, super::WINDOW_HEIGHT)
+        .with_inner_size(config.window_width, config.window_height)
         .with_vsync(true)
         .build(&event_loop);
 
-    let mut viewer = Viewer::new(&display, db, conn);
+    let mut viewer = Viewer::new(&display, config, db, conn);
 
     struct State {
         last_mouse_xy: PhysicalPosition<f64>,

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -2,30 +2,17 @@ mod model_viewer;
 mod main_loop;
 mod viewer;
 mod fps;
+mod config;
+
+use config::Config;
 
 use crate::cli::Args;
 use crate::db::Database;
 use crate::connection::{Connection, ConnectionOptions};
 use crate::errors::Result;
 
-/// Initial window width.
-pub static WINDOW_WIDTH: u32 = 640;
-/// Initial window height.
-pub static WINDOW_HEIGHT: u32 = 480;
-/// Window background color.
-pub static BG_COLOR: (f32, f32, f32, f32) = (0.3, 0.3, 0.3, 1.0);
-/// Near-plane distance for perspective.
-pub static Z_NEAR: f32 = 0.01;
-/// Far-plane distance for perspective.
-pub static Z_FAR: f32 = 4000.0;
-/// Vertical field-of-view for perspective (radians).
-pub static FOV_Y: f32 = 1.1;
-/// Animation framerate (seconds/frame)
-pub static FRAMERATE: f64 = 1.0 / 60.0;
-/// Calculate FPS over intervals of this length (seconds).
-pub static FPS_INTERVAL: f64 = 2.0;
-
 pub fn main(args: &Args) -> Result<()> {
+    let config = Config::from_cli_args(args)?;
     let db = Database::from_cli_args(args)?;
     db.print_status();
 
@@ -40,7 +27,7 @@ pub fn main(args: &Args) -> Result<()> {
     // Print the controls
     println!("{}", viewer::CONTROL_HELP);
 
-    main_loop::main_loop(db, conn);
+    main_loop::main_loop(&config, db, conn);
 
     Ok(())
 }

--- a/src/viewer/model_viewer/mod.rs
+++ b/src/viewer/model_viewer/mod.rs
@@ -21,12 +21,12 @@ type Display = glium::Display<glium::glutin::surface::WindowSurface>;
 /// * use update_vertices after, eg, you move to a new animation frame of the
 ///   same model
 /// * use update_materials when the textures on the materials change
-pub struct ModelViewer {
+pub struct ModelViewer<'a> {
     pub eye: Eye,
     pub aspect_ratio: f32,
     pub light_on: bool,
 
-    config: Config,
+    config: &'a Config,
 
     /// Program for unlit materials (using vertex colors)
     unlit_program: Program,
@@ -51,8 +51,8 @@ pub enum MaterialTextureBinding {
     ImageId(ImageId),
 }
 
-impl ModelViewer {
-    pub fn new(display: &Display, config: &Config) -> ModelViewer {
+impl<'a> ModelViewer<'a> {
+    pub fn new(display: &Display, config: &'a Config) -> ModelViewer<'a> {
         let unlit_vertex_shader = include_str!("shaders/vert_unlit.glsl");
         let lit_vertex_shader = include_str!("shaders/vert_lit.glsl");
         let fragment_shader = include_str!("shaders/frag.glsl");
@@ -83,7 +83,7 @@ impl ModelViewer {
 
         ModelViewer {
             eye: Default::default(),
-            config: config.clone(),
+            config: config,
             aspect_ratio: 1.0,
             light_on: true,
             unlit_program,

--- a/src/viewer/model_viewer/mod.rs
+++ b/src/viewer/model_viewer/mod.rs
@@ -9,7 +9,7 @@ use glium::{VertexBuffer, IndexBuffer, Frame, Surface, Program};
 use crate::nitro::Model;
 use crate::primitives::{Primitives, DrawCall, Vertex};
 use self::texture_cache::{TextureCache, ImageId};
-use super::{Z_NEAR, Z_FAR, FOV_Y};
+use super::config::Config;
 
 type Display = glium::Display<glium::glutin::surface::WindowSurface>;
 
@@ -25,6 +25,8 @@ pub struct ModelViewer {
     pub eye: Eye,
     pub aspect_ratio: f32,
     pub light_on: bool,
+
+    config: Config,
 
     /// Program for unlit materials (using vertex colors)
     unlit_program: Program,
@@ -50,7 +52,7 @@ pub enum MaterialTextureBinding {
 }
 
 impl ModelViewer {
-    pub fn new(display: &Display) -> ModelViewer {
+    pub fn new(display: &Display, config: &Config) -> ModelViewer {
         let unlit_vertex_shader = include_str!("shaders/vert_unlit.glsl");
         let lit_vertex_shader = include_str!("shaders/vert_lit.glsl");
         let fragment_shader = include_str!("shaders/frag.glsl");
@@ -81,6 +83,7 @@ impl ModelViewer {
 
         ModelViewer {
             eye: Default::default(),
+            config: config.clone(),
             aspect_ratio: 1.0,
             light_on: true,
             unlit_program,
@@ -163,10 +166,10 @@ impl ModelViewer {
         // Model-view-projection matrix
         let model_view = self.eye.model_view();
         let persp: Matrix4<f32> = PerspectiveFov {
-            fovy: Rad(FOV_Y),
+            fovy: Rad(self.config.fov_y),
             aspect: self.aspect_ratio,
-            near: Z_NEAR,
-            far: Z_FAR,
+            near: self.config.z_near,
+            far: self.config.z_far,
         }.into();
         let model_view_persp = persp * model_view;
         let model_view_persp: [[f32; 4]; 4] = model_view_persp.into();

--- a/src/viewer/viewer.rs
+++ b/src/viewer/viewer.rs
@@ -13,11 +13,11 @@ use super::fps::FpsCounter;
 
 type Display = glium::Display<glium::glutin::surface::WindowSurface>;
 
-pub struct Viewer {
-    config: Config,
+pub struct Viewer<'b> {
+    config: &'b Config,
     db: Database,
     conn: Connection,
-    model_viewer: ModelViewer,
+    model_viewer: ModelViewer<'b>,
 
     /// ID of the current model.
     model_id: ModelId,
@@ -37,7 +37,7 @@ pub struct Viewer {
     /// Accumulator for time.
     time_acc: f64,
     /// Keeps track of the FPS.
-    fps_counter: FpsCounter,
+    fps_counter: FpsCounter<'b>,
     /// Direction of motion (for the WASD controls).
     move_vector: Vector3<f32>,
     /// Movement speed (for WASD) as an index into the SPEEDS array.
@@ -126,14 +126,14 @@ pub static CONTROL_HELP: &'static str =
     );
 
 
-impl Viewer {
-    pub fn new(display: &Display, config: &Config, db: Database, conn: Connection) -> Viewer {
+impl<'b> Viewer<'b> {
+    pub fn new(display: &Display, config: &'b Config, db: Database, conn: Connection) -> Viewer<'b> {
         let model_viewer = ModelViewer::new(&display, config);
 
         // Create a viewer for model 0
         assert!(db.models.len() > 0);
         let mut viewer = Viewer {
-            config: config.clone(),
+            config: config,
             db,
             conn,
             model_viewer,

--- a/src/viewer/viewer.rs
+++ b/src/viewer/viewer.rs
@@ -8,12 +8,13 @@ use winit::keyboard::{KeyCode, ModifiersState};
 use crate::nitro::{Model, Animation, Pattern, MaterialAnimation};
 use crate::primitives::{Primitives, PolyType, DynamicState};
 use cgmath::{Matrix4, InnerSpace, Vector3, vec3, vec2};
+use super::config::Config;
 use super::fps::FpsCounter;
-use super::{FRAMERATE, BG_COLOR};
 
 type Display = glium::Display<glium::glutin::surface::WindowSurface>;
 
 pub struct Viewer {
+    config: Config,
     db: Database,
     conn: Connection,
     model_viewer: ModelViewer,
@@ -126,12 +127,13 @@ pub static CONTROL_HELP: &'static str =
 
 
 impl Viewer {
-    pub fn new(display: &Display, db: Database, conn: Connection) -> Viewer {
-        let model_viewer = ModelViewer::new(&display);
+    pub fn new(display: &Display, config: &Config, db: Database, conn: Connection) -> Viewer {
+        let model_viewer = ModelViewer::new(&display, config);
 
         // Create a viewer for model 0
         assert!(db.models.len() > 0);
         let mut viewer = Viewer {
+            config: config.clone(),
             db,
             conn,
             model_viewer,
@@ -143,7 +145,7 @@ impl Viewer {
             pat_state: AnimState::none(),
             mat_anim_state: AnimState::none(),
             time_acc: 0.0,
-            fps_counter: FpsCounter::new(),
+            fps_counter: FpsCounter::new(config),
             move_vector: vec3(0.0, 0.0, 0.0),
             speed_idx: DEFAULT_SPEED_IDX,
         };
@@ -169,7 +171,7 @@ impl Viewer {
             self.time_acc = 1.0;
         }
 
-        while self.time_acc > FRAMERATE {
+        while self.time_acc > self.config.animation_framerate {
             if !self.anim_state.single_stepping {
                 self.next_anim_frame();
             }
@@ -179,12 +181,12 @@ impl Viewer {
             if !self.mat_anim_state.single_stepping {
                 self.next_mat_anim_frame();
             }
-            self.time_acc -= FRAMERATE;
+            self.time_acc -= self.config.animation_framerate;
         }
     }
 
     pub fn draw(&self, frame: &mut Frame) {
-        frame.clear_color_srgb_and_depth(BG_COLOR, 1.0);
+        frame.clear_color_srgb_and_depth(self.config.bg_color, 1.0);
         self.model_viewer.draw(frame, self.cur_model(&self.db))
     }
 


### PR DESCRIPTION
Related to #65 

Adds command line flags for the `view` subcommand to allow the user to configure the following settings that were previously hard-coded constants:

* Window width and height (`--window-width` and `--window-height`)
* Animation playback speed (`--animation-fps`)
* Background color (`--bg-color`)

```bash
apicula.exe view \
    --window-width 1000 \
    --window-height 800 \
    --animation-fps 30 \
    --bg-color "#00ff00" \
    *
```